### PR TITLE
commit more functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ pip install -e vos-benchmark
 (from the vos-benchmark root directory)
 
 ```bash
-python benchmark.py -g <path to ground-truth directory> -m <path to prediction directory> -n <number of processes, 16 by default>
+python benchmark.py -g <paths to ground-truth directory> -m <paths to prediction directory> -n <number of processes, 16 by default>
+# e.g. python benchmark.py -g /path/to/ground-truth1 /path/to/ground-truth2 -m /path/to/prediction1 /path/to/prediction2 -n 16
 ```
 
 ### Using it as a library:
@@ -48,8 +49,10 @@ We read the input masks using `Image.open` from PIL. Paletted png files and gray
 2. We determine the objects in a frame (ground-truth or prediction) with `np.unique`. If there are any types of antialiasing, blurring, smoothing, etc., that spawn new pixel values, this will not work.
 3. From the start of the video, we keep a list of all objects that are seen in either ground-truth or prediction. This is to support datasets where some ground-truth objects appear later in the frame. Predicting objects that are not in the ground-truth harms the final score.
 4. By default, we skip the first and the last frame during evaluation. This is in line with the standard semi-supervised video object segmentation evaluation protocol in DAVIS. This can be overridden by specifying `-d` or `--do_not_skip_first_and_last_frame`, or passing `skip_first_and_last=False` (if used as a package).
-5. By default, we don't care if all the videos in the ground-truth folder have corresponding predictions. This is to support datasets that contain videos from different splits (e.g., DAVIS puts train/val splits together) in a single folder. If the prediction only contains videos from the validation set, we would only evaluate those videos. This can be overridden by specifying `-s` or `--strict`, or passing `strict=True` (if used as a package). In the strict mode, an exception would be thrown if the sets of videos do not match.
-6. If a video is being evaluated, all the frames in the ground-truth folder must have corresponding predictions. Predictions that do not have corresponding ground-truths are simply ignored.
+5. You can pass text files by specifying `-v` or `--video_names` to indicate which videos to evaluate. The text files should contain the names of the videos (without the extension). The text files should contain same videos as the prediction folders and . The text files should have the same name as the prediction folders and be subset of ground-truth folders.
+6. If you don't pass the text files: By default, we don't care if all the videos in the ground-truth folder have corresponding predictions. This is to support datasets that contain videos from different splits (e.g., DAVIS puts train/val splits together) in a single folder. If the prediction only contains videos from the validation set, we would only evaluate those videos. This can be overridden by specifying `-s` or `--strict`, or passing `strict=True` (if used as a package). In the strict mode, an exception would be thrown if the sets of videos do not match.
+7. If a video is being evaluated, all the frames in the ground-truth folder must have corresponding predictions. Predictions that do not have corresponding ground-truths are simply ignored.
+8. If the `results.csv` file already exists in the prediction folder, it will be skipped. This is to prevent accidental overwriting. If you want to overwrite it, specify `-o` or `--overwrite`, or pass `overwrite=True` (if used as a package).
 
 ## Related projects:
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -19,6 +19,9 @@ parser.add_argument('-n', '--num_processes',
 parser.add_argument('-s', '--strict',
                     help='Make sure every video in the ground-truth has a corresponding video in the prediction',
                     action='store_true')
+parser.add_argument('--not_full_mask',
+                    help='Some video not contains full mask',
+                    action='store_true')
 parser.add_argument('--overwrite',
                     help='Overwrite existing results',
                     action='store_true')
@@ -35,6 +38,7 @@ benchmark(
     mask_roots=args.mask,
     video_names=args.video_names,
     strict=args.strict,
+    full_mask=not args.not_full_mask,
     overwrite=args.overwrite,
     num_processes=args.num_processes,
     verbose=True,

--- a/benchmark.py
+++ b/benchmark.py
@@ -10,6 +10,9 @@ parser.add_argument('-g', '--gt',
 parser.add_argument('-m', '--mask',
                     nargs="*", default=[], type=str,
                     help='Path to a folder containing folders of masks to be evaluated')
+parser.add_argument('-v', '--video_names',
+                    nargs="*", default=[], type=str,
+                    help='Path to a txt containing videos to be evaluated')
 parser.add_argument('-n', '--num_processes',
                     default=16, type=int,
                     help='Number of concurrent processes')
@@ -33,6 +36,7 @@ args = parser.parse_args()
 benchmark(
     gt_roots=args.gt,
     mask_roots=args.mask,
+    video_names=args.video_names,
     strict=args.strict,
     overwrite=args.overwrite,
     num_processes=args.num_processes,

--- a/benchmark.py
+++ b/benchmark.py
@@ -24,13 +24,10 @@ parser.add_argument('--overwrite',
                     action='store_true')
 
 # https://github.com/davisvideochallenge/davis2017-evaluation/blob/d34fdef71ce3cb24c1a167d860b707e575b3034c/davis2017/evaluation.py#L85
-parser.add_argument(
-    '-d',
-    '--do_not_skip_first_and_last_frame',
-    help=
-    'By default, we skip the first and the last frame in evaluation following DAVIS semi-supervised evaluation.'
-    'They should not be skipped in unsupervised evaluation.',
-    action='store_true')
+parser.add_argument('-d', '--do_not_skip_first_and_last_frame',
+                    help='By default, we skip the first and the last frame in evaluation following DAVIS semi-supervised evaluation. They should not be skipped in unsupervised evaluation.',
+                    action='store_true')
+
 args = parser.parse_args()
 
 benchmark(

--- a/benchmark.py
+++ b/benchmark.py
@@ -4,9 +4,11 @@ from vos_benchmark.benchmark import benchmark
 Data paths
 """
 parser = ArgumentParser()
-parser.add_argument('-g', '--gt', help='Path to a folder containing folders of ground-truth masks')
-parser.add_argument('-m',
-                    '--mask',
+parser.add_argument('-g', '--gt',
+                    nargs="*", default=[], type=str,
+                    help='Path to a folder containing folders of ground-truth masks')
+parser.add_argument('-m', '--mask',
+                    nargs="*", default=[], type=str,
                     help='Path to a folder containing folders of masks to be evaluated')
 parser.add_argument('-n',
                     '--num_processes',
@@ -29,8 +31,11 @@ parser.add_argument(
     action='store_true')
 args = parser.parse_args()
 
-benchmark([args.gt], [args.mask],
-          args.strict,
-          args.num_processes,
-          verbose=True,
-          skip_first_and_last=not args.do_not_skip_first_and_last_frame)
+benchmark(
+    gt_roots=args.gt,
+    mask_roots=args.mask,
+    strict=args.strict,
+    num_processes=args.num_processes,
+    verbose=True,
+    skip_first_and_last=not args.do_not_skip_first_and_last_frame
+)

--- a/benchmark.py
+++ b/benchmark.py
@@ -10,16 +10,15 @@ parser.add_argument('-g', '--gt',
 parser.add_argument('-m', '--mask',
                     nargs="*", default=[], type=str,
                     help='Path to a folder containing folders of masks to be evaluated')
-parser.add_argument('-n',
-                    '--num_processes',
-                    default=16,
-                    type=int,
+parser.add_argument('-n', '--num_processes',
+                    default=16, type=int,
                     help='Number of concurrent processes')
-parser.add_argument(
-    '-s',
-    '--strict',
-    help='Make sure every video in the ground-truth has a corresponding video in the prediction',
-    action='store_true')
+parser.add_argument('-s', '--strict',
+                    help='Make sure every video in the ground-truth has a corresponding video in the prediction',
+                    action='store_true')
+parser.add_argument('--overwrite',
+                    help='Overwrite existing results',
+                    action='store_true')
 
 # https://github.com/davisvideochallenge/davis2017-evaluation/blob/d34fdef71ce3cb24c1a167d860b707e575b3034c/davis2017/evaluation.py#L85
 parser.add_argument(
@@ -35,6 +34,7 @@ benchmark(
     gt_roots=args.gt,
     mask_roots=args.mask,
     strict=args.strict,
+    overwrite=args.overwrite,
     num_processes=args.num_processes,
     verbose=True,
     skip_first_and_last=not args.do_not_skip_first_and_last_frame

--- a/eval.sh
+++ b/eval.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+path_list=(
+    "/data1/zhangjiaming/results_Tracking_Anything/v4_convmae_mask2former/1230-1-fix.yaml/Jan08_06.08.25_v4_convmae_mask2former_1230-1-fix_s6/Jan08_06.08.25_v4_convmae_mask2former_1230-1-fix_s6_200000.pth/TrackingAnything_1230-test.txt-memory_store_every{5}-memory_max_number{1}-model_topk{30}"
+    "/data1/zhangjiaming/results_Tracking_Anything/v4_convmae_mask2former/1230-1-fix.yaml/Jan08_06.08.25_v4_convmae_mask2former_1230-1-fix_s6/Jan08_06.08.25_v4_convmae_mask2former_1230-1-fix_s6_201000.pth/TrackingAnything_1230-test.txt-memory_store_every{5}-memory_max_number{1}-model_topk{30}"
+    "/data1/zhangjiaming/results_Tracking_Anything/v4_convmae_mask2former/1230-1-fix.yaml/Jan08_06.08.25_v4_convmae_mask2former_1230-1-fix_s6/Jan08_06.08.25_v4_convmae_mask2former_1230-1-fix_s6_202000.pth/TrackingAnything_1230-test.txt-memory_store_every{5}-memory_max_number{1}-model_topk{30}"
+    "/data1/zhangjiaming/results_Tracking_Anything/v4_convmae_mask2former/1230-1-fix.yaml/Jan08_06.08.25_v4_convmae_mask2former_1230-1-fix_s6/Jan08_06.08.25_v4_convmae_mask2former_1230-1-fix_s6_203000.pth/TrackingAnything_1230-test.txt-memory_store_every{5}-memory_max_number{1}-model_topk{30}"
+    "/data1/zhangjiaming/results_Tracking_Anything/v4_convmae_mask2former/1230-1-fix.yaml/Jan08_06.08.25_v4_convmae_mask2former_1230-1-fix_s6/Jan08_06.08.25_v4_convmae_mask2former_1230-1-fix_s6_204000.pth/TrackingAnything_1230-test.txt-memory_store_every{5}-memory_max_number{1}-model_topk{30}"
+    "/data1/zhangjiaming/results_Tracking_Anything/v4_convmae_mask2former/1230-1-fix.yaml/Jan08_06.08.25_v4_convmae_mask2former_1230-1-fix_s6/Jan08_06.08.25_v4_convmae_mask2former_1230-1-fix_s6_205000.pth/TrackingAnything_1230-test.txt-memory_store_every{5}-memory_max_number{1}-model_topk{30}"
+    "/data1/zhangjiaming/results_Tracking_Anything/v4_convmae_mask2former/1230-1-fix.yaml/Jan08_06.08.25_v4_convmae_mask2former_1230-1-fix_s6/Jan08_06.08.25_v4_convmae_mask2former_1230-1-fix_s6_206000.pth/TrackingAnything_1230-test.txt-memory_store_every{5}-memory_max_number{1}-model_topk{30}"
+    "/data1/zhangjiaming/results_Tracking_Anything/v4_convmae_mask2former/1230-1-fix.yaml/Jan08_06.08.25_v4_convmae_mask2former_1230-1-fix_s6/Jan08_06.08.25_v4_convmae_mask2former_1230-1-fix_s6_207000.pth/TrackingAnything_1230-test.txt-memory_store_every{5}-memory_max_number{1}-model_topk{30}"
+    "/data1/zhangjiaming/results_Tracking_Anything/v4_convmae_mask2former/1230-1-fix.yaml/Jan08_06.08.25_v4_convmae_mask2former_1230-1-fix_s6/Jan08_06.08.25_v4_convmae_mask2former_1230-1-fix_s6_208000.pth/TrackingAnything_1230-test.txt-memory_store_every{5}-memory_max_number{1}-model_topk{30}"
+    "/data1/zhangjiaming/results_Tracking_Anything/v4_convmae_mask2former/1230-1-fix.yaml/Jan08_06.08.25_v4_convmae_mask2former_1230-1-fix_s6/Jan08_06.08.25_v4_convmae_mask2former_1230-1-fix_s6_209000.pth/TrackingAnything_1230-test.txt-memory_store_every{5}-memory_max_number{1}-model_topk{30}"
+    "/data1/zhangjiaming/results_Tracking_Anything/v4_convmae_mask2former/1230-1-fix.yaml/Jan08_06.08.25_v4_convmae_mask2former_1230-1-fix_s6/Jan08_06.08.25_v4_convmae_mask2former_1230-1-fix_s6_210000.pth/TrackingAnything_1230-test.txt-memory_store_every{5}-memory_max_number{1}-model_topk{30}"
+)
+
+for path in "${path_list[@]}"; do
+    echo "Current path: $path"
+
+    python benchmark.py \
+    -n 16 \
+    -g /data1/zhangjiaming/datasets/Tracking_Anything/Tracking_Anything_Dataset/first_stage/Annotations \
+    -m $path \
+    -v /data1/zhangjiaming/datasets/Tracking_Anything/Tracking_Anything_Dataset/first_stage/ImageSets/1230-test.txt
+done

--- a/show.py
+++ b/show.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import os
+
+# 定义包含多个CSV文件路径的列表
+csv_paths = [
+    "/data1/zhangjiaming/results_Tracking_Anything/v4_convmae_mask2former/1230-v3.yaml/Jan08_16.07.13_v4_convmae_mask2former_1230-v3_s6/Jan08_16.07.13_v4_convmae_mask2former_1230-v3_s6_450000.pth/",
+]
+
+result_name = 'TrackingAnything_1230-test.txt-memory_store_every{5}-memory_max_number{1}-model_topk{30}'
+csv_name = 'results.csv'
+
+for path in csv_paths:
+    csv_path = os.path.join(path, result_name, csv_name)
+    try:
+        df = pd.read_csv(csv_path)
+        print(df.iloc[0, 2])
+
+    except Exception as e:
+        print(f"Error reading {csv_path}", )

--- a/vos_benchmark/benchmark.py
+++ b/vos_benchmark/benchmark.py
@@ -1,6 +1,5 @@
 import os
 from os import path
-import pandas as pd
 import time
 from multiprocessing import Pool
 
@@ -77,6 +76,7 @@ def benchmark(gt_roots,
                 then it must at least contain all the masks in the ground truth annotations.
                 Masks that are in the prediction but not in the ground-truth
                 (i.e., sparse annotations) are ignored.
+    overwrite: whether overwrite existing results.csv
     skip_first_and_last: whether we should skip the first and the last frame in evaluation.
                             This is used by DAVIS 2017 in their semi-supervised evaluation.
                             It should be disabled for unsupervised evaluation.

--- a/vos_benchmark/benchmark.py
+++ b/vos_benchmark/benchmark.py
@@ -1,5 +1,6 @@
 import os
 from os import path
+import pandas as pd
 import time
 from multiprocessing import Pool
 
@@ -50,6 +51,7 @@ class VideoEvaluator:
 def benchmark(gt_roots,
               mask_roots,
               strict=True,
+              overwrite=False,
               num_processes=None,
               *,
               verbose=True,
@@ -82,6 +84,20 @@ def benchmark(gt_roots,
 
     assert len(gt_roots) == len(mask_roots)
     single_dataset = (len(gt_roots) == 1)
+
+    # check if results.csv already exists, decide to skip or overwrite
+    skip_indices = []
+    for i in range(len(mask_roots)):
+        mask_root = mask_roots[i]
+        if path.exists(path.join(mask_root, 'results.csv')):
+            if not overwrite:
+                print(f'{mask_root}/results.csv already exists. Skipping.')
+                skip_indices.append(i)
+            else:
+                print(f'{mask_root}/results.csv already exists. But we will remove and overwrite it.')
+                os.remove(path.join(mask_root, 'results.csv'))
+    mask_roots = [mask_roots[i] for i in range(len(mask_roots)) if i not in skip_indices]
+    gt_roots = [gt_roots[i] for i in range(len(gt_roots)) if i not in skip_indices]
 
     if verbose:
         if skip_first_and_last:


### PR DESCRIPTION
We add more convenient and help functions:

- Support for entering multiple paths on the command line, separated by spaces
- args.video_names: pass multiple file paths to indicate which videos to evaluate
- args.overwrite: If the `results.csv` file already exists in the prediction folder, it will be skipped. This is to prevent accidental overwriting. If you want to overwrite it, specify `-o` or `--overwrite`, or pass `overwrite=True` (if used as a package).